### PR TITLE
Add ability to inline edit translations

### DIFF
--- a/src/Dropdown.tsx
+++ b/src/Dropdown.tsx
@@ -58,7 +58,7 @@ export function Dropdown(props: { options: DropdownOptions }) {
           // if we find a matching pair
           if(item.nearestVisibleAncestor && item.nearestVisibleAncestor.isSameNode(entry.target)) {
             item.isIntersecting = entry.isIntersecting;
-          } 
+          }
         }
       }
       return result;
@@ -75,7 +75,7 @@ export function Dropdown(props: { options: DropdownOptions }) {
     // rootMargin?: string;
     threshold: options.intersectionThreshold,
   }))
-  
+
   /**
    * Whenever changes are made to the DOM, adjust translatedNodes accordingly
    * This includes:
@@ -96,77 +96,130 @@ export function Dropdown(props: { options: DropdownOptions }) {
             // check if this is a Node we even want, reusing our custom filter
             if(customTreeWalker.customFilter.acceptNode(node) === NodeFilter.FILTER_ACCEPT) {
               // make sure this node isn't one we're already watching
-              // TODO: rework for attribute nodes
-              /**
-               * TODO: rework for attribute nodes
-               * - we aren't going to mess with attributes here because 
-               *   we're within the context of customTreeWalker.customFilter.
-               *   in this context, we're ONLY dealing with nodeValue/text nodes
-               * - change condition to "! existsInside(result, e => ... && e.attributeType === 'text' )"
-               *   or something like that
-               */
-              if(! existsInside(result, e => e.node.isSameNode(node))) {
-                const nativeLang: TranslatedTextMap = {};
-                nativeLang[options.pageLanguage] = node.nodeValue ?? '';
-                const nativeStatus: TranslationStatusMap = {};
-                nativeStatus[options.pageLanguage] = TranslationStatus.Translated;
+              if (node.nodeType === Node.TEXT_NODE) {
+                if(! existsInside(result, e => (e.node.isSameNode(node) && e.attribute === '_text_'))) {
+                  const originalText = node.nodeValue ?? '';
+                  if (originalText !== ''){
+                    const nativeLang: TranslatedTextMap = {};
+                    nativeLang[options.pageLanguage] = originalText;
+                    const nativeStatus: TranslationStatusMap = {};
+                    nativeStatus[options.pageLanguage] = TranslationStatus.Translated;
 
-                const ancestor = getNearestVisibleAncestor(node);
+                    const ancestor = getNearestVisibleAncestor(node);
 
-                // add to intersection observer
-                if(ancestor) intersectionObserver.current.observe(ancestor);
+                    // add to intersection observer
+                    if(ancestor) intersectionObserver.current.observe(ancestor);
 
-                result.push({
-                  originalText: node.nodeValue ?? '',
-                  currentLanguage: options.pageLanguage,
-                  translatedText: {},
-                  translationStatus: nativeStatus,
-                  node,
-                  isIntersecting: false,
-                  nearestVisibleAncestor: ancestor
-                });
+                    result.push({
+                      originalText: originalText,
+                      currentLanguage: options.pageLanguage,
+                      translatedText: {},
+                      translationStatus: nativeStatus,
+                      node,
+                      isIntersecting: false,
+                      nearestVisibleAncestor: ancestor,
+                      attribute: '_text_'
+                    });
+                  }
+                }
+              } else if (node instanceof HTMLElement && options.includedAttributes.length > 0) {
+                for(let attrName of options.includedAttributes) {
+                  if (node.hasAttribute(attrName)){
+                    if(! existsInside(result, e => (e.node.isSameNode(node) && e.attribute === attrName))) {
+                      const originalText = node.getAttribute(attrName) ?? '';
+                      if (originalText !== ''){
+                        const nativeLang: TranslatedTextMap = {};
+                        nativeLang[options.pageLanguage] = originalText;
+                        const nativeStatus: TranslationStatusMap = {};
+                        nativeStatus[options.pageLanguage] = TranslationStatus.Translated;
+
+                        const ancestor = node;
+
+                        // add to intersection observer
+                        if(ancestor) intersectionObserver.current.observe(ancestor);
+
+                        result.push({
+                          originalText: originalText,
+                          currentLanguage: options.pageLanguage,
+                          translatedText: {},
+                          translationStatus: nativeStatus,
+                          node,
+                          isIntersecting: false,
+                          nearestVisibleAncestor: ancestor,
+                          attribute: attrName
+                        });
+                      }
+                    }
+                  }
+                }
+
               }
+
             }
             // if this is not a Node that we want, maybe it's children are
             else {
-              const children = customTreeWalker.textNodesUnder(node);
+              const children = customTreeWalker.validNodesUnder(node);
               for(let child of children) {
                 // make sure this node isn't one we're already watching
-                // TODO: same as above
-                if(! existsInside(result, e => e.node.isSameNode(child))) {
-                  const nativeLang: TranslatedTextMap = {};
-                  nativeLang[options.pageLanguage] = child.nodeValue ?? '';
-                  const nativeStatus: TranslationStatusMap = {};
-                  nativeStatus[options.pageLanguage] = TranslationStatus.Translated;
+                if (child.nodeType === Node.TEXT_NODE){
+                  if(! existsInside(result, e => (e.node.isSameNode(child) && e.attribute === '_text_'))) {
+                    const originalText = child.nodeValue ?? '';
+                    if (originalText !== ''){
+                      const nativeLang: TranslatedTextMap = {};
+                      nativeLang[options.pageLanguage] = originalText;
+                      const nativeStatus: TranslationStatusMap = {};
+                      nativeStatus[options.pageLanguage] = TranslationStatus.Translated;
 
-                  const ancestor = getNearestVisibleAncestor(child);
+                      const ancestor = getNearestVisibleAncestor(child);
 
-                  // add to intersection observer
-                  if(ancestor) intersectionObserver.current.observe(ancestor);
+                      // add to intersection observer
+                      if(ancestor) intersectionObserver.current.observe(ancestor);
 
-                  result.push({
-                    originalText: child.nodeValue ?? '',
-                    currentLanguage: options.pageLanguage,
-                    translatedText: nativeLang,
-                    translationStatus: nativeStatus,
-                    node: child,
-                    isIntersecting: false,
-                    nearestVisibleAncestor: ancestor
-                  });
+                      result.push({
+                        originalText: originalText,
+                        currentLanguage: options.pageLanguage,
+                        translatedText: {},
+                        translationStatus: nativeStatus,
+                        node:child,
+                        isIntersecting: false,
+                        nearestVisibleAncestor: ancestor,
+                        attribute: '_text_'
+                      });
+                    }
+                  }
+                } else if (child instanceof HTMLElement && options.includedAttributes.length > 0) {
+                  for(let attrName of options.includedAttributes) {
+                    if (child.hasAttribute(attrName)){
+                      if(! existsInside(result, e => (e.node.isSameNode(child) && e.attribute === attrName))) {
+                        const originalText = child.getAttribute(attrName) ?? '';
+                        if (originalText !== ''){
+                          const nativeLang: TranslatedTextMap = {};
+                          nativeLang[options.pageLanguage] = originalText;
+                          const nativeStatus: TranslationStatusMap = {};
+                          nativeStatus[options.pageLanguage] = TranslationStatus.Translated;
+
+                          const ancestor = child;
+
+                          // add to intersection observer
+                          if(ancestor) intersectionObserver.current.observe(ancestor);
+
+                          result.push({
+                            originalText: originalText,
+                            currentLanguage: options.pageLanguage,
+                            translatedText: {},
+                            translationStatus: nativeStatus,
+                            node:child,
+                            isIntersecting: false,
+                            nearestVisibleAncestor: ancestor,
+                            attribute: attrName
+                          });
+                        }
+                      }
+                    }
+                  }
                 }
               }
             }
-
-            /**
-             * TODO:
-             * - above, we checked for nodes which satisfy our criteria for text/"nodeValue" nodes
-             * - below, we're going to do the same thing but for "attribute" nodes
-             * - a custom tree walker would probably help. in fact, it might be perfect
-             *   because it means that we can reuse code and copy/paste patterns that
-             *   already work well.
-             */
-
-            // TODO: insert code here
           }
           // Remove the removed nodes from translatedNodes
           for(let i = 0; i < mutation.removedNodes.length; i++) {
@@ -176,59 +229,59 @@ export function Dropdown(props: { options: DropdownOptions }) {
             // TODO: similar to above, make sure this only affects text/"nodeValue" nodes
             if(customTreeWalker.customFilter.acceptNode(node) === NodeFilter.FILTER_ACCEPT) {
               // find the index of this node in translatedNodes
-              const index = result.findIndex(e => e.node.isSameNode(node));
-              // check if this is a node we're watching
-              if(index >= 0) {
-
-                // remove from intersection observer
-                /**
-                 * TODO: make sure we aren't "unobserve"ing a shared ancestor
-                 * - this should only be called if there is only 1 node which has this ancestor value
-                 * - if there are multiple nodes that have this ancestor value, just delete this 
-                 *   node and skip "unobserve"
-                 * - when the last node which contains this "ancestor" is removed, this condition 
-                 *   will kick in and then we will properly "unobserve"
-                 */
-                if(result[index].nearestVisibleAncestor) intersectionObserver.current.unobserve(result[index].nearestVisibleAncestor!);
-
-                // remove it
-                result.splice(index, 1);
+              if (node.nodeType === Node.TEXT_NODE){
+                const index = result.findIndex(e => (e.node.isSameNode(node) && e.attribute === '_text_'));
+                if(index >= 0) {
+                  if(result[index].nearestVisibleAncestor) intersectionObserver.current.unobserve(result[index].nearestVisibleAncestor!);
+                  // remove it
+                  result.splice(index, 1);
+                }
+              } else if (node instanceof HTMLElement && options.includedAttributes.length > 0) {
+                for(let attrName of options.includedAttributes) {
+                  const index = result.findIndex(e => (e.node.isSameNode(node) && e.attribute === attrName));
+                  if(index >= 0) {
+                    if(result[index].nearestVisibleAncestor) intersectionObserver.current.unobserve(result[index].nearestVisibleAncestor!);
+                    // remove it
+                    result.splice(index, 1);
+                  }
+                }
               }
             }
             // if this is not a Node that we want, maybe it's children are
             else {
-              const children = customTreeWalker.textNodesUnder(node);
+              const children = customTreeWalker.validNodesUnder(node);
               for(let child of children) {
-                // find the index of this node in translatedNodes
-                const index = result.findIndex(e => e.node.isSameNode(child)); // TODO: inefficient
-                // check if this is a node we're watching
-                if(index >= 0) {
-
-                  // remove from intersection observer
-                  // TODO: similar to above, shared ancestor
-                  if(result[index].nearestVisibleAncestor) intersectionObserver.current.unobserve(result[index].nearestVisibleAncestor!);
-
-                  // remove it
-                  result.splice(index, 1);
+                if (child.nodeType === Node.TEXT_NODE){
+                  const index = result.findIndex(e => (e.node.isSameNode(child) && e.attribute === '_text_'));
+                  if(index >= 0) {
+                    if(result[index].nearestVisibleAncestor) intersectionObserver.current.unobserve(result[index].nearestVisibleAncestor!);
+                    // remove it
+                    result.splice(index, 1);
+                  }
+                } else if (child instanceof HTMLElement && options.includedAttributes.length > 0) {
+                  for(let attrName of options.includedAttributes) {
+                    const index = result.findIndex(e => (e.node.isSameNode(child) && e.attribute === attrName));
+                    if(index >= 0) {
+                      if(result[index].nearestVisibleAncestor) intersectionObserver.current.unobserve(result[index].nearestVisibleAncestor!);
+                      // remove it
+                      result.splice(index, 1);
+                    }
+                  }
                 }
               }
             }
-
-            // TODO: similar to above, process for "attribute" nodes
-            
-            // TODO: insert code here
           }
         }
         // If the text of an element changed
         /**
-         * TODO: 
+         * TODO:
          * - mutation type 'characterData' ONLY affects text/"nodeValue" nodes!
          * - take action accordingly
          */
         if(mutation.type === 'characterData') {
 
           // find the index of this node in translatedNodes
-          const index = result.findIndex(e => e.node.isSameNode(mutation.target));
+          const index = result.findIndex(e => (e.node.isSameNode(mutation.target) && e.attribute === '_text_'));
           // check if this is a node we're watching
           if(index >= 0) {
             // check if the mutation was NOT as a result of translating, and instead was updated by some other factor
@@ -286,14 +339,14 @@ export function Dropdown(props: { options: DropdownOptions }) {
       // if we only want a handful of languages to show instead of the entire list
       if(options.preferredSupportedLanguages.length > 1) {
         setSupportedLanguages(x => [
-          ...x, 
+          ...x,
           ...data
             .filter(e => options.preferredSupportedLanguages.includes(e.languageCode))
         ]);
       }
       else {
         setSupportedLanguages(x => [
-          ...x, 
+          ...x,
           ...data
         ]);
       }
@@ -324,31 +377,60 @@ export function Dropdown(props: { options: DropdownOptions }) {
     // if translatedNodes is not initialized, initialize it
     if(translatedNodes.length === 0) {
       // get all leaf text nodes
-      const nodes = customTreeWalker.textNodesUnder(document.body);
-      // TODO: get nodes with attributes
-      // compose our result
-      setTranslatedNodes(nodes.map(node => {
-        const nativeLang: TranslatedTextMap = {};
-        nativeLang[options.pageLanguage] = node.nodeValue ?? ''; // TODO: something else depending on type field
-        const nativeStatus: TranslationStatusMap = {};
-        nativeStatus[options.pageLanguage] = TranslationStatus.Translated;
+      const nodes = customTreeWalker.validNodesUnder(document.body);
+      for(let node of nodes){
+        if (node.nodeType === Node.TEXT_NODE) {
+          const originalText = node.nodeValue ?? '';
+          if (originalText !== ''){
+            const nativeLang: TranslatedTextMap = {};
+            nativeLang[options.pageLanguage] = originalText;
+            const nativeStatus: TranslationStatusMap = {};
+            nativeStatus[options.pageLanguage] = TranslationStatus.Translated;
 
-        const ancestor = getNearestVisibleAncestor(node);
+            const ancestor = getNearestVisibleAncestor(node);
 
-        // add to intersection observer
-        if(ancestor) intersectionObserver.current.observe(ancestor);
+            // add to intersection observer
+            if(ancestor) intersectionObserver.current.observe(ancestor);
 
-        return {
-          originalText: node.nodeValue ?? '',
-          currentLanguage: options.pageLanguage,
-          translatedText: nativeLang,
-          translationStatus: nativeStatus,
-          node,
-          isIntersecting: false,
-          nearestVisibleAncestor: ancestor,
-          // TODO: set some properties that distinguish text nodes from attribute nodes
+            setTranslatedNodes( prevList => [...prevList, {
+              originalText: originalText,
+              currentLanguage: options.pageLanguage,
+              translatedText: nativeLang,
+              translationStatus: nativeStatus,
+              node,
+              isIntersecting: false,
+              nearestVisibleAncestor: ancestor,
+              attribute: '_text_'
+            }]);
+          }
         }
-      }));
+        if (node instanceof HTMLElement){
+          for(let attrName of options.includedAttributes) {
+            const originalText = node.getAttribute(attrName) ?? '';
+            if (originalText !== ''){
+              const nativeLang: TranslatedTextMap = {};
+              nativeLang[options.pageLanguage] = originalText;
+              const nativeStatus: TranslationStatusMap = {};
+              nativeStatus[options.pageLanguage] = TranslationStatus.Translated;
+              const ancestor = node;
+
+              // add to intersection observer
+              if(ancestor) intersectionObserver.current.observe(ancestor);
+
+              setTranslatedNodes( prevList => [...prevList, {
+                originalText: originalText,
+                currentLanguage: options.pageLanguage,
+                translatedText: nativeLang,
+                translationStatus: nativeStatus,
+                node,
+                isIntersecting: false,
+                nearestVisibleAncestor: ancestor,
+                attribute: attrName
+              }]);
+            }
+          }
+        }
+      }
     }
     // if translatedNodes is already initialized
     else {
@@ -357,8 +439,8 @@ export function Dropdown(props: { options: DropdownOptions }) {
         (async () => {
           // filter translatedNodes to get a list of nodes that aren't translated to the current language, AND that are visible in the viewport currently
           const needsTranslating = translatedNodes
-            .filter(e => e.translatedText[language] === undefined && 
-              (e.translationStatus[language] === undefined ||  
+            .filter(e => e.translatedText[language] === undefined &&
+              (e.translationStatus[language] === undefined ||
               e.translationStatus[language] === TranslationStatus.NotTranslated) &&
               (options.ignoreIntersection === true || e.isIntersecting === true));
 
@@ -389,7 +471,7 @@ export function Dropdown(props: { options: DropdownOptions }) {
                 const results = previous.slice();
                 for(let i = 0; i < chunk.length; i++) {
                   // find where this chunk's node exists in the state
-                  const index = results.findIndex(e => e.node.isSameNode(chunk[i].node));
+                  const index = results.findIndex(e => (e.node.isSameNode(chunk[i].node) && e.attribute === chunk[i].attribute));
                   // if we could find it, update the state
                   if(index >= 0) {
                     results[index].translatedText[language] = data[i];
@@ -416,8 +498,17 @@ export function Dropdown(props: { options: DropdownOptions }) {
             for(let i = 0; i < results.length; i++) {
               // if "currentLanguage" is different from the dropdown setting
               if(results[i].currentLanguage !== language && results[i].translatedText[language] !== undefined) {
-                results[i].node.nodeValue = results[i].translatedText[language] ?? ''; // TODO: do something different depending on type
                 results[i].currentLanguage = language;
+                if (results[i].attribute === "_text_"){
+                  results[i].node.nodeValue = results[i].translatedText[language] ?? ''; // TODO: do something different depending on type
+                } else {
+                  let node = results[i].node;
+                  if (node instanceof Element){
+                    let attr = results[i].attribute;
+                    let translatedText = results[i].translatedText[language] ?? '';
+                    node.setAttribute(attr, translatedText);
+                  }
+                }
               }
             }
             return results;
@@ -468,12 +559,12 @@ export function Dropdown(props: { options: DropdownOptions }) {
       </select>
       { options.attributionImageUrl ? <img className={styles.attribution} src={options.attributionImageUrl} /> : <></>}
       {showBanner ? createPortal(
-        <Banner 
-          pageLanguage={options.pageLanguage} 
-          language={language} 
-          supportedLanguages={supportedLanguages} 
-          logoImageUrl={options.logoImageUrl} 
-          isLoading={isLoading} 
+        <Banner
+          pageLanguage={options.pageLanguage}
+          language={language}
+          supportedLanguages={supportedLanguages}
+          logoImageUrl={options.logoImageUrl}
+          isLoading={isLoading}
           buttons={options.buttons}
           handleExit={handleExit}
           handleLanguageChange={handleChange} />

--- a/src/EditTranslation.tsx
+++ b/src/EditTranslation.tsx
@@ -1,0 +1,53 @@
+import React, { useEffect, useState } from 'react'
+
+interface EditTranslationProps {
+  initialText: string;
+  targetElement: HTMLElement;
+  initWidth: number;
+  initHeight: number;
+  onSave: (text:string, initialText:string, targetElement:HTMLElement) => void;
+  onCancel: (initialText:string, targetElement:HTMLElement) => void;
+}
+
+export function EditTranslationComponent(props: EditTranslationProps) {
+  const [text, setText] = React.useState(props.initialText);
+  const [width, setWidth] = useState(100);
+  const [height, setHeight] = useState(30);
+
+  const handleSave = () => {
+    props.onSave(text, props.initialText, props.targetElement);
+  };
+
+  const handleCancel = () => {
+    props.onCancel(props.initialText, props.targetElement);
+  };
+
+  const handleTextareaClick = (event:React.MouseEvent) => {
+    event.stopPropagation();
+  };
+
+  useEffect(() => {
+    document.addEventListener('keydown', (event) => {
+        if (event.key === 'Escape') {
+          props.onCancel(props.initialText, props.targetElement);
+        }
+    });
+
+    setWidth(Math.max(width, props.initWidth));
+    setHeight(Math.max(height, props.initHeight));
+
+  }, []);
+
+  return (
+    <span>
+        <textarea
+            className="skiptranslate"
+            style={{ width: `${width}px`, height: `${height}px` }}
+            value={text}
+            onClick={handleTextareaClick}
+            onChange={(e) => setText(e.target.value)} />
+        <button className="btn btn-primary skiptranslate" onClick={handleSave}>Save</button>
+        <button className="btn btn-danger skiptranslate" onClick={handleCancel}>Cancel</button>
+    </span>
+  );
+};

--- a/src/customTreeWalker.ts
+++ b/src/customTreeWalker.ts
@@ -13,12 +13,12 @@ export class CustomTreeWalker {
     this.customFilter = {
       /**
        * FILTER_ACCEPT 	Value returned by the NodeFilter.acceptNode() method when a node should be accepted.
-       * 
+       *
        * FILTER_REJECT 	Value to be returned by the NodeFilter.acceptNode() method when a node should be rejected. For TreeWalker, child nodes are also rejected.
-       * 
+       *
        * FILTER_SKIP 	  Value to be returned by NodeFilter.acceptNode() for nodes to be skipped by the NodeIterator or TreeWalker object.
        *                The children of skipped nodes are still considered. This is treated as "skip this node but not its children".
-       * @param node 
+       * @param node
        */
       acceptNode(node: Node): number {
         // skip parents with `.skiptranslate`
@@ -41,6 +41,14 @@ export class CustomTreeWalker {
             return NodeFilter.FILTER_REJECT
           }
         }
+        if (node instanceof HTMLElement && options.includedAttributes.length > 0) {
+          for(let attrName of options.includedAttributes) {
+            // If node has the included attribute, accept it
+            if(node.hasAttribute(attrName)) {
+              return NodeFilter.FILTER_ACCEPT
+            }
+          }
+        }
         // skip nodes that have children
         if(node.childNodes.length > 0) {
           return NodeFilter.FILTER_SKIP
@@ -57,8 +65,11 @@ export class CustomTreeWalker {
         if(node.parentNode && forbiddenTags.includes(node.parentNode.nodeName.toLocaleLowerCase())) {
           return NodeFilter.FILTER_REJECT
         }
-        // accept others
-        return NodeFilter.FILTER_ACCEPT
+        // If this is a TEXT_NODE, accept
+        if (node.nodeType === Node.TEXT_NODE) {
+          return NodeFilter.FILTER_ACCEPT
+        }
+        return NodeFilter.FILTER_REJECT
       }
     };
   }
@@ -66,8 +77,8 @@ export class CustomTreeWalker {
   /**
    * From: https://stackoverflow.com/a/10730777
    */
-  textNodesUnder(el: Node) {
-    var n, a=[], walk=document.createTreeWalker(el, NodeFilter.SHOW_TEXT, this.customFilter);
+  validNodesUnder(el: Node) {
+    var n, a=[], walk=document.createTreeWalker(el, NodeFilter.SHOW_ELEMENT | NodeFilter.SHOW_TEXT, this.customFilter);
     while(n=walk.nextNode()) a.push(n);
     return a;
   }

--- a/src/models.ts
+++ b/src/models.ts
@@ -32,4 +32,5 @@ export interface TranslatedNode {
   node: Node;
   isIntersecting: boolean;
   nearestVisibleAncestor: HTMLElement | null;
+  attribute: string;
 }

--- a/src/options.ts
+++ b/src/options.ts
@@ -35,18 +35,18 @@ export interface DropdownOptions {
    */
   ignoreIntersection: boolean;
   /**
-   * Classes to ignore when translating. Useful for specifing other widgets or third-party sections 
+   * Classes to ignore when translating. Useful for specifing other widgets or third-party sections
    * where adding the ".skiptranslate" class is impractical.
-   * 
-   * Example: 
+   *
+   * Example:
    *  Ignore Google Place Autocomplete popovers
    *  ['pac-container', 'pac-logo']
    */
   ignoreClasses: string[];
   /**
-   * Selectors to ignore when translating. Useful for specifing other widgets or third-party sections 
+   * Selectors to ignore when translating. Useful for specifing other widgets or third-party sections
    * where adding the ".skiptranslate" class is impractical.
-   * 
+   *
    * uses Element.matches() on candidate nodes
    * see: https://developer.mozilla.org/en-US/docs/Web/API/Element/matches
    */
@@ -64,11 +64,21 @@ export interface DropdownOptions {
    * Used for specifying custom buttons which appear at the top right
    * of the banner next to the "close" button. Useful for providing
    * a better UX such as custom instructions or functionality.
-   * 
+   *
    * Some pre-included icons are 'help' or 'info', otherwise include
    * a URL to an image.
    */
   buttons: BannerButton[];
+  /**
+   * List attributes in elements to be included in the translation
+   *
+   * Example:
+   *  ['title', 'alt']
+   *
+   * Defaults to:
+   *  ['title', 'placeholder', 'alt']
+   */
+  includedAttributes: string[];
   /**
    * URL of the endpoints for the API backing this widget
    */

--- a/src/options.ts
+++ b/src/options.ts
@@ -84,6 +84,7 @@ export interface DropdownOptions {
    */
   endpoints: {
     supportedLanguages: string;
+    updateTranslation: string;
     translate: string;
   }
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -14,10 +14,10 @@ export function getFlagEmoji(countryCode: string) {
  * From: https://stackoverflow.com/a/37826698
  */
 export function chunkedArray<T>(inputArray: T[], perChunk: number): T[][] {
-  // var perChunk = 2 // items per chunk    
+  // var perChunk = 2 // items per chunk
   // var inputArray = ['a','b','c','d','e']
 
-  var result = inputArray.reduce<T[][]>((resultArray, item, index) => { 
+  var result = inputArray.reduce<T[][]>((resultArray, item, index) => {
     const chunkIndex = Math.floor(index/perChunk)
 
     if(!resultArray[chunkIndex]) {
@@ -67,9 +67,15 @@ export function existsInside<T>(array: T[], predicate: (value: T, index: number,
 }
 
 export async function translate(endpoint: string, text: string[], from: string, to: string, siteName: string): Promise<string[]> {
-  const res = await fetch(`${endpoint}?from=${from}&to=${to}&siteName=${siteName}`, {
+  const res = await fetch(endpoint, {
     method: 'POST',
-    body: JSON.stringify(text),
+    body:  JSON.stringify({
+      'from': from,
+      'to': to,
+      'siteName': siteName,
+      'text': text,
+      'page_url': window.location.href,
+    }),
     headers: {
       'Content-Type': 'application/json'
     },
@@ -81,5 +87,33 @@ export async function translate(endpoint: string, text: string[], from: string, 
   }
   else {
     throw `Data returned from endpoint was not of type string[] (Endpoint: ${endpoint}), data: ${JSON.stringify(data)}`
+  }
+}
+
+
+export async function update_translation(endpoint: string, originalText: string, text: string, from: string, to: string, siteName: string): Promise<boolean> {
+  const res = await fetch(endpoint, {
+    method: 'POST',
+    body: JSON.stringify({
+      'from': from,
+      'to': to,
+      'siteName': siteName,
+      'originalText': originalText,
+      'text': text
+    }),
+    headers: {
+      'Content-Type': 'application/json'
+    },
+  });
+  const data = await res.json();
+  if (!("status" in data)){
+    throw `Invalid data returned from endpoint (Endpoint: ${endpoint}), data: ${JSON.stringify(data)}`
+  }
+
+  if(data.status == 'Success') {
+    return true;
+  }
+  else {
+    return false;
   }
 }

--- a/src/widget.tsx
+++ b/src/widget.tsx
@@ -21,6 +21,7 @@ export function initHook(args: any, mountLocation: string) {
     verboseOutput: extract(args, 'verboseOutput', false),
     updateDocumentLanguageAttribute: extract(args, 'updateDocumentLanguageAttribute', false),
     buttons: extract(args, 'buttons', []),
+    includedAttributes: extract(args, 'includedAttributes', ['title', 'placeholder', 'alt']),
     endpoints: {
       //supportedLanguages: 'http://wlinux.wsl:3000/api/v3/supportedLanguages',
       //translate: 'http://wlinux.wsl:3000/api/v3/translate'

--- a/src/widget.tsx
+++ b/src/widget.tsx
@@ -26,6 +26,7 @@ export function initHook(args: any, mountLocation: string) {
       //supportedLanguages: 'http://wlinux.wsl:3000/api/v3/supportedLanguages',
       //translate: 'http://wlinux.wsl:3000/api/v3/translate'
       supportedLanguages: extract(args, ['endpoints', 'supportedLanguages'], 'https://google-translate-sample.vercel.app/api/legacy/supportedLanguages'),
+      updateTranslation: extract(args, ['endpoints', 'updateTranslation'], ''),
       translate: extract(args, ['endpoints', 'translate'], 'https://google-translate-sample.vercel.app/api/legacy/translate')
     }
   };


### PR DESCRIPTION
If the backend API allows it, you can provide an `updateTranslation` endpoint to the `translateWidget` init parameters. If that is the case, there's an advanced feature that gets enabled, that will show an edit pencil over translated chunks. When clicking on it, an edit `<textarea>` will show up where the translation can be edited and saved. This is how it works:

When the translation feature kicks in, you get the content translated (As normal):
![Original](https://github.com/au5ton/rosetta/assets/851006/b33dec58-ce53-40fd-9237-aad419436fdf)
While holding `Ctrl` and hovering over it, you will get the edit pencil with a border showing what is going to be edited:
![Hovering](https://github.com/au5ton/rosetta/assets/851006/711e393d-614f-4e66-8ed6-6ed3160d0053)
After clicking the edit pencil, you get a `<textarea>` with the translation to edit:
![Updating Translation](https://github.com/au5ton/rosetta/assets/851006/9ddaf155-efde-4197-8865-86a26af959bb)
Finally, clicking `Save` will send the updated translation to the backend endpoint, and update the element:
![Translation Updated](https://github.com/au5ton/rosetta/assets/851006/54f078aa-3956-48a7-8bbd-a5f579bf851d)