### PR TITLE
Update openapi.yaml, README and missing parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ Technically, their widget [stills works if you have the code for it](https://www
   [https://web.archive.org/web/20180801033735/https://translate.google.com/manager/website/](https://web.archive.org/web/20180801033735/https://translate.google.com/manager/website/)
 
 - Current page:
-  
+
   [https://translate.google.com/intl/en/about/website/](https://translate.google.com/intl/en/about/website/)
 
 - Announcement of temporary support during the COVID-19 pandemic:
-  
+
   [https://developers.google.com/search/blog/2020/05/google-translates-website-translator](https://developers.google.com/search/blog/2020/05/google-translates-website-translator)
 
 ## Goal
@@ -116,6 +116,11 @@ For a complete list of options and what they do, see [options.ts](src/options.ts
   </script>
   <script src="https://cdn.jsdelivr.net/gh/au5ton/rosetta@0.5.1/dist/index.js" onload="widgetTranslateElementInit()"></script>
 ```
+
+### Update translations in back-end
+
+The translation UI supports updating the translations in the back-end if an optional `updateTranslation` endpoint is provided. The idea is that the back-end caches the translations, and so the website maintainer can update these translations. If this `updateTranslation` endpoint is provided, then by hovering over the translations with the `Ctrl` key pressed, you will get a button to edit a translation.
+There's more information in [This issue](https://github.com/au5ton/rosetta/pull/32).
 
 ### Back-end
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,10 @@ For a complete list of options and what they do, see [options.ts](src/options.ts
   <script src="https://cdn.jsdelivr.net/gh/au5ton/rosetta@0.5.1/dist/index.js" onload="widgetTranslateElementInit()"></script>
 ```
 
+### Translate attributes
+
+In addition to visible text, rosetta can also translate attributes in tags, such as `title` on `<img>` and so on. The list of attributes can be specified with the `includedAttributes` option. It defaults to `title`, `placeholder` and `alt`.
+
 ### Update translations in back-end
 
 The translation UI supports updating the translations in the back-end if an optional `updateTranslation` endpoint is provided. The idea is that the back-end caches the translations, and so the website maintainer can update these translations. If this `updateTranslation` endpoint is provided, then by hovering over the translations with the `Ctrl` key pressed, you will get a button to edit a translation.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -21,40 +21,11 @@ paths:
     post:
       summary: Translate some text
       operationId: translate
-      parameters:
-      - name: to
-        in: query
-        description: The target language to translate to
-        required: true
-        schema:
-          type: string
-      - name: from
-        in: query
-        description: The source language to translate from
-        required: true
-        schema:
-          type: string
-      - name: format
-        in: query
-        description: The format that the provided text is in, either `text` or `html`.
-        required: false
-        schema:
-          type: string
-          default: 'text'
-      - name: siteName
-        in: query
-        description: An optional identifier for the site being translated
-        required: false
-        schema:
-          type: string
       requestBody:
-        description: The text that is intended to be translated
         content:
           application/json:
             schema:
-              type: array
-              items:
-                type: string
+              $ref: '#/components/schemas/Translate'
         required: true
       responses:
         405:
@@ -92,8 +63,55 @@ paths:
         400:
           description: Invalid status value
           content: {}
+  /updateTranslation:
+    post:
+      operationId: updateTranslation
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/updateTranslation'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema: {}
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Update Translation
 components:
   schemas:
+    Translate:
+      properties:
+        from:
+          title: From
+          type: string
+        to:
+          title: To
+          type: string
+        siteName:
+          default: ''
+          title: Sitename
+          type: string
+        text:
+          items:
+            type: string
+          title: Text
+          type: array
+        page_url:
+          title: Page Url
+          type: string
+      required:
+        - from
+        - to
+        - text
+      type: object
     SupportedLanguage:
       type: object
       properties:
@@ -101,3 +119,60 @@ components:
           type: string
         displayName:
           type: string
+    updateTranslation:
+      properties:
+        from:
+          title: From
+          type: string
+        to:
+          title: To
+          type: string
+        siteName:
+          default: ''
+          title: Sitename
+          type: string
+        originalText:
+          title: Originaltext
+          type: string
+        text:
+          title: Text
+          type: string
+        page_url:
+          title: Page Url
+          type: string
+      required:
+        - from
+        - to
+        - originalText
+        - text
+      type: object
+    HTTPValidationError:
+      properties:
+        detail:
+          items:
+            $ref: '#/components/schemas/ValidationError'
+          title: Detail
+          type: array
+      title: HTTPValidationError
+      type: object
+    ValidationError:
+      properties:
+        loc:
+          items:
+            anyOf:
+            - type: string
+            - type: integer
+          title: Location
+          type: array
+        msg:
+          title: Message
+          type: string
+        type:
+          title: Error Type
+          type: string
+      required:
+      - loc
+      - msg
+      - type
+      title: ValidationError
+      type: object

--- a/src/util.ts
+++ b/src/util.ts
@@ -99,7 +99,8 @@ export async function update_translation(endpoint: string, originalText: string,
       'to': to,
       'siteName': siteName,
       'originalText': originalText,
-      'text': text
+      'text': text,
+      'page_url': window.location.href,
     }),
     headers: {
       'Content-Type': 'application/json'


### PR DESCRIPTION
Hey @au5ton here's the updated openapi.yaml and README. 

When I was updating it, I noticed that with #32 I accidentally included a change where the call to `/translate` would not send the `to`, `from` and `siteName` as query parameters, since that's a `POST` request, and instead are sent in the `BODY`, and so I updated the `openapi.yaml` acordingly. Let me know if you would want to revert this change, else I believe this can be merged. 